### PR TITLE
Fix broken Github and add link to text as per #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![NPM version](https://img.shields.io/npm/v/vue-embed-gist.svg?style=flat)](https://npmjs.com/package/vue-embed-gist) [![NPM downloads](https://img.shields.io/npm/dm/vue-embed-gist.svg?style=flat)](https://npmjs.com/package/vue-embed-gist) [![CircleCI](https://circleci.com/gh/sudhanshu-15/vue-embed-gist/tree/master.svg?style=shield)](https://circleci.com/gh/sudhanshu-15/vue-embed-gist/tree/master)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](code_of_conduct.md)
 
-Vue component to embed Github Gists, inspired by Blair Vanderhoof's gist-embed. (https://github.com/blairvanderhoof/gist-embed)
+Vue component to embed Github Gists, inspired by Blair Vanderhoof's [gist-embed](https://github.com/blairvanderhoof/gist-embed).
 
 ## Demo
 
-[Demo of vue-embed-gist](https://sudhanshu-15.github.io/vue-embed-gist)
+[Demo of vue-embed-gist](https://sudhanshu-15.github.io/vue-embed-gist/)
 
 ## Install
 


### PR DESCRIPTION

### What is in this PR:

fix issue #24 and add the link to the GitHub repo to the 'gist-embed' text itself rather than as a separate link.


